### PR TITLE
Fixing equilibrium reactor notebook

### DIFF
--- a/idaes_examples/notebooks/docs/unit_models/reactors/equilibrium_reactor_src.ipynb
+++ b/idaes_examples/notebooks/docs/unit_models/reactors/equilibrium_reactor_src.ipynb
@@ -261,7 +261,6 @@
     "    has_heat_of_reaction=True,\n",
     "    has_heat_transfer=True,\n",
     "    has_pressure_change=False,\n",
-    "    has_phase_equilibrium=True,\n",
     ")"
    ]
   },


### PR DESCRIPTION
# Related to https://github.com/IDAES/idaes-pse/pull/1145

The equilibrium reactor notebook was setting the reactor to include phase equilibrium reactions, but only one phase was defined in the property package (thus phase equilibrium is undefined). Previously this passed without notice, but https://github.com/IDAES/idaes-pse/pull/1145 means this will now raise an `Exception` to inform the user that this does not make sense.

This PR removes the line to include phase equilibrium in the reactor, which has no effect on the results of the notebook.

----
Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

    I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
    I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
