### PR TITLE
Fix Outdated PETSc Install Information

### DIFF
--- a/idaes_examples/notebooks/docs/dae/petsc_chem_src.ipynb
+++ b/idaes_examples/notebooks/docs/dae/petsc_chem_src.ipynb
@@ -45,7 +45,7 @@
    "source": [
     "## Prerequisites\n",
     "\n",
-    "The PETSc solver is an extra download for IDAES.  The solver is available for Linux, but can be run in the Windows environment via the WSL (Windows Subsystem for Linux).  The WSL method of running the solver works smoothly in the normal Windows workflow.  PETSc installation details for Linux and Windows are available along with the documentation (https://idaes-pse.readthedocs.io/en/stable/reference_guides/core/solvers.html)."
+    "The PETSc solver is an extra download for IDAES, which can be downloaded using the command ```idaes get-extensions --extra petsc```, if it is not installed already. (https://idaes-pse.readthedocs.io/en/stable/reference_guides/core/solvers.html)."
    ]
   },
   {
@@ -565,7 +565,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -579,7 +579,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/idaes_examples/notebooks/docs/dae/petsc_chem_src.ipynb
+++ b/idaes_examples/notebooks/docs/dae/petsc_chem_src.ipynb
@@ -45,7 +45,7 @@
    "source": [
     "## Prerequisites\n",
     "\n",
-    "The PETSc solver is an extra download for IDAES, which can be downloaded using the command ```idaes get-extensions --extra petsc```, if it is not installed already. (https://idaes-pse.readthedocs.io/en/stable/reference_guides/core/solvers.html)."
+    "The PETSc solver is an extra download for IDAES, which can be downloaded using the command ```idaes get-extensions --extra petsc```, if it is not installed already. See the IDAES solver documentation for more information (https://idaes-pse.readthedocs.io/en/stable/reference_guides/core/solvers.html)."
    ]
   },
   {

--- a/idaes_examples/notebooks/docs/dae/petsc_pid_src.ipynb
+++ b/idaes_examples/notebooks/docs/dae/petsc_pid_src.ipynb
@@ -56,7 +56,7 @@
    "source": [
     "## Prerequisites\n",
     "\n",
-    "The PETSc solver is an extra download for IDAES, which can be downloaded using the command ```idaes get-extensions --extra petsc```, if it is not installed already. (https://idaes-pse.readthedocs.io/en/stable/reference_guides/core/solvers.html).\n",
+    "The PETSc solver is an extra download for IDAES, which can be downloaded using the command ```idaes get-extensions --extra petsc```, if it is not installed already. See the IDAES solver documentation for more information (https://idaes-pse.readthedocs.io/en/stable/reference_guides/core/solvers.html).\n",
     "\n",
     "You may want to review the [\"PETSc Time-stepping Solver -- Chemical Akzo Nobel Example\"](petsc_chem_example.ipynb) notebook first."
    ]

--- a/idaes_examples/notebooks/docs/dae/petsc_pid_src.ipynb
+++ b/idaes_examples/notebooks/docs/dae/petsc_pid_src.ipynb
@@ -56,7 +56,7 @@
    "source": [
     "## Prerequisites\n",
     "\n",
-    "The PETSc solver is an extra download for IDAES.  The solver is available for Linux, but can be run in the Windows environment via the WSL (Windows Subsystem for Linux).  The WSL method of running the solver works smoothly in the normal Windows workflow.  PETSc installation details for Linux and Windows are available along with the documentation (https://idaes-pse.readthedocs.io/en/stable/reference_guides/core/solvers.html).\n",
+    "The PETSc solver is an extra download for IDAES, which can be downloaded using the command ```idaes get-extensions --extra petsc```, if it is not installed already. (https://idaes-pse.readthedocs.io/en/stable/reference_guides/core/solvers.html).\n",
     "\n",
     "You may want to review the [\"PETSc Time-stepping Solver -- Chemical Akzo Nobel Example\"](petsc_chem_example.ipynb) notebook first."
    ]


### PR DESCRIPTION
# Fix Outdated PETSc Install Information

There were a couple of outdated sentences in the DAE examples about PETSc only being available for Linux and WSL.  It's now natively available on all platforms (even macOS). 

----
Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

    I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
    I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.


<!-- readthedocs-preview idaes-examples start -->
----
:books: Documentation preview :books:: https://idaes-examples--32.org.readthedocs.build/en/32/

<!-- readthedocs-preview idaes-examples end -->