### PR TITLE
Fix misspelled argument

### DIFF
--- a/idaes_examples/mod/power_gen/steam_turbine.py
+++ b/idaes_examples/mod/power_gen/steam_turbine.py
@@ -374,7 +374,7 @@ class SteamTurbineFlowsheetData(FlowsheetBlockData):
             outlvl=outlvl,
             solver=solver,
             optarg=optarg,
-            copy_disconneted_flow=False,
+            copy_disconnected_flow=False,
             calculate_inlet_cf=True,
             calculate_outlet_cf=True,
         )


### PR DESCRIPTION
# Fix misspelled argument

Due to some recent spelling corrections in IDAES there was a misspelled argument in the NGCC example.  The error only shows up when you initialize from nothing not when loading an initial state, so the tests didn't pick it up.  

----
Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

    I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
    I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.


<!-- readthedocs-preview idaes-examples start -->
----
:books: Documentation preview :books:: https://idaes-examples--45.org.readthedocs.build/en/45/

<!-- readthedocs-preview idaes-examples end -->