### PR TITLE
Correct units in PFR example

### DIFF
--- a/idaes_examples/notebooks/docs/unit_models/reactors/plug_flow_reactor_src.ipynb
+++ b/idaes_examples/notebooks/docs/unit_models/reactors/plug_flow_reactor_src.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "e734deab",
    "metadata": {
     "tags": [
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "scrolled": true
    },
@@ -209,7 +209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "scrolled": true
    },
@@ -230,7 +230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "scrolled": false
    },
@@ -260,7 +260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -307,7 +307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,12 +324,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, let us add expressions to compute the reactor cooling cost (\\\\$/s) assuming a cost of 2.12E-5 \\\\$/kW, and the heating utility cost (\\\\$/s) assuming 2.2E-4 \\\\$/kW. Note that the heat duty is in units of watt (J/s). The total operating cost will be the sum of the two, expressed in \\\\$/year assuming 8000 operating hours per year (~10\\% downtime, which is fairly common for small scale chemical plants):"
+    "Now, let us add expressions to compute the reactor cooling cost (\\\\$/s) assuming a cost of 2.12E-5 \\\\$/kW, and the heating utility cost (\\\\$/s) assuming 2.2E-4 \\\\$/kW. To calculate cooling cost it is important to note that the heatd duty is not constant through the reactors length. Which is why we utilize the trapezoid rule to calculate the total heat duty of the reactor:$Q=\\Delta x\\big(\\sum_{k=1}^{N-1}(Q_k)+\\frac{Q_N+Q_0}{2}\\big)$ \n",
+    "where k is the subinvterval in the length domain and N is the number of intervals.\n",
+    "Note that the heat duty is in units of watt (J/s). The total operating cost will be the sum of the two, expressed in \\\\$/year assuming 8000 operating hours per year (~10\\% downtime, which is fairly common for small scale chemical plants):"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
     "scrolled": true
    },
@@ -337,7 +339,9 @@
    "source": [
     "m.fs.cooling_cost = Expression(\n",
     "    expr=2.12e-8\n",
-    "    * (-sum(m.fs.R101.heat_duty[0, x] for x in m.fs.R101.control_volume.length_domain))\n",
+    "    * (-sum(m.fs.R101.heat_duty[0, k] for k in  m.fs.R101.control_volume.length_domain if 0.0 <= k < 1.0)) \n",
+    "    - (value(m.fs.R101.heat_duty[0, m.fs.R101.control_volume.length_domain.at(1)])\n",
+    "    - value(m.fs.R101.heat_duty[0, m.fs.R101.control_volume.length_domain.at(-1)]))/2\n",
     ")  # the reaction is exothermic, so R101 duty is negative\n",
     "m.fs.heating_cost = Expression(\n",
     "    expr=2.2e-7 * m.fs.H101.heat_duty[0]\n",
@@ -358,18 +362,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "35\n"
+     ]
+    }
+   ],
    "source": [
     "print(degrees_of_freedom(m))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {
     "tags": [
      "testing"
@@ -390,7 +402,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -436,7 +448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -452,7 +464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {
     "scrolled": false
    },
@@ -492,12 +504,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
     "m.fs.R101.heat_duty.setub(\n",
-    "    0 * pyunits.J / pyunits.s\n",
+    "    0 * pyunits.J / pyunits.m / pyunits.s\n",
     ")  # heat duty is only used for cooling"
    ]
   },
@@ -510,16 +522,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0\n"
+     ]
+    }
+   ],
    "source": [
     "print(degrees_of_freedom(m))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {
     "tags": [
      "testing"
@@ -540,9 +560,47 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2023-05-25 20:05:42 [INFO] idaes.init.fs.OXIDE.properties: Starting initialization\n",
+      "2023-05-25 20:05:42 [INFO] idaes.init.fs.OXIDE.properties: Property initialization: optimal - Optimal Solution Found.\n",
+      "2023-05-25 20:05:42 [INFO] idaes.init.fs.OXIDE.properties: Property package initialization: optimal - Optimal Solution Found.\n",
+      "2023-05-25 20:05:42 [INFO] idaes.init.fs.OXIDE: Initialization Complete.\n",
+      "2023-05-25 20:05:42 [INFO] idaes.init.fs.ACID.properties: Starting initialization\n",
+      "2023-05-25 20:05:42 [INFO] idaes.init.fs.ACID.properties: Property initialization: optimal - Optimal Solution Found.\n",
+      "2023-05-25 20:05:42 [INFO] idaes.init.fs.ACID.properties: Property package initialization: optimal - Optimal Solution Found.\n",
+      "2023-05-25 20:05:42 [INFO] idaes.init.fs.ACID: Initialization Complete.\n",
+      "2023-05-25 20:05:43 [INFO] idaes.init.fs.M101.reagent_feed_state: Starting initialization\n",
+      "2023-05-25 20:05:43 [INFO] idaes.init.fs.M101.reagent_feed_state: Property initialization: optimal - Optimal Solution Found.\n",
+      "2023-05-25 20:05:43 [INFO] idaes.init.fs.M101.catalyst_feed_state: Starting initialization\n",
+      "2023-05-25 20:05:43 [INFO] idaes.init.fs.M101.catalyst_feed_state: Property initialization: optimal - Optimal Solution Found.\n",
+      "2023-05-25 20:05:43 [INFO] idaes.init.fs.M101.mixed_state: Starting initialization\n",
+      "2023-05-25 20:05:43 [INFO] idaes.init.fs.M101.mixed_state: Property initialization: optimal - Optimal Solution Found.\n",
+      "2023-05-25 20:05:43 [INFO] idaes.init.fs.M101.mixed_state: Property package initialization: optimal - Optimal Solution Found.\n",
+      "2023-05-25 20:05:43 [INFO] idaes.init.fs.M101: Initialization Complete: optimal - Optimal Solution Found\n",
+      "2023-05-25 20:05:43 [INFO] idaes.init.fs.H101.control_volume.properties_in: Starting initialization\n",
+      "2023-05-25 20:05:43 [INFO] idaes.init.fs.H101.control_volume.properties_in: Property initialization: optimal - Optimal Solution Found.\n",
+      "2023-05-25 20:05:43 [INFO] idaes.init.fs.H101.control_volume.properties_out: Starting initialization\n",
+      "2023-05-25 20:05:44 [INFO] idaes.init.fs.H101.control_volume.properties_out: Property initialization: optimal - Optimal Solution Found.\n",
+      "2023-05-25 20:05:44 [INFO] idaes.init.fs.H101.control_volume: Initialization Complete\n",
+      "2023-05-25 20:05:44 [INFO] idaes.init.fs.H101: Initialization Complete: optimal - Optimal Solution Found\n",
+      "2023-05-25 20:05:44 [INFO] idaes.init.fs.R101.control_volume.properties: Starting initialization\n",
+      "2023-05-25 20:05:44 [INFO] idaes.init.fs.R101.control_volume.properties: Property initialization: optimal - Optimal Solution Found.\n",
+      "2023-05-25 20:05:44 [INFO] idaes.init.fs.R101.control_volume.reactions: Initialization Complete.\n",
+      "2023-05-25 20:05:44 [INFO] idaes.init.fs.R101.control_volume: Initialization Complete\n",
+      "2023-05-25 20:05:44 [INFO] idaes.init.fs.R101: Initialization Complete: optimal - Optimal Solution Found\n",
+      "2023-05-25 20:05:44 [INFO] idaes.init.fs.PROD.properties: Starting initialization\n",
+      "2023-05-25 20:05:44 [INFO] idaes.init.fs.PROD.properties: Property initialization: optimal - Optimal Solution Found.\n",
+      "2023-05-25 20:05:44 [INFO] idaes.init.fs.PROD.properties: Property package initialization: optimal - Optimal Solution Found.\n",
+      "2023-05-25 20:05:44 [INFO] idaes.init.fs.PROD: Initialization Complete.\n"
+     ]
+    }
+   ],
    "source": [
     "# Initialize and solve each unit operation\n",
     "m.fs.OXIDE.initialize()\n",
@@ -568,11 +626,87 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ipopt 3.13.2: nlp_scaling_method=gradient-based\n",
+      "tol=1e-06\n",
+      "max_iter=200\n",
+      "\n",
+      "\n",
+      "******************************************************************************\n",
+      "This program contains Ipopt, a library for large-scale nonlinear optimization.\n",
+      " Ipopt is released as open source code under the Eclipse Public License (EPL).\n",
+      "         For more information visit http://projects.coin-or.org/Ipopt\n",
+      "\n",
+      "This version of Ipopt was compiled from source code available at\n",
+      "    https://github.com/IDAES/Ipopt as part of the Institute for the Design of\n",
+      "    Advanced Energy Systems Process Systems Engineering Framework (IDAES PSE\n",
+      "    Framework) Copyright (c) 2018-2019. See https://github.com/IDAES/idaes-pse.\n",
+      "\n",
+      "This version of Ipopt was compiled using HSL, a collection of Fortran codes\n",
+      "    for large-scale scientific computation.  All technical papers, sales and\n",
+      "    publicity material resulting from use of the HSL codes within IPOPT must\n",
+      "    contain the following acknowledgement:\n",
+      "        HSL, a collection of Fortran codes for large-scale scientific\n",
+      "        computation. See http://www.hsl.rl.ac.uk.\n",
+      "******************************************************************************\n",
+      "\n",
+      "This is Ipopt version 3.13.2, running with linear solver ma27.\n",
+      "\n",
+      "Number of nonzeros in equality constraint Jacobian...:     1923\n",
+      "Number of nonzeros in inequality constraint Jacobian.:        0\n",
+      "Number of nonzeros in Lagrangian Hessian.............:     1323\n",
+      "\n",
+      "Total number of variables............................:      608\n",
+      "                     variables with only lower bounds:        0\n",
+      "                variables with lower and upper bounds:      257\n",
+      "                     variables with only upper bounds:       20\n",
+      "Total number of equality constraints.................:      608\n",
+      "Total number of inequality constraints...............:        0\n",
+      "        inequality constraints with only lower bounds:        0\n",
+      "   inequality constraints with lower and upper bounds:        0\n",
+      "        inequality constraints with only upper bounds:        0\n",
+      "\n",
+      "iter    objective    inf_pr   inf_du lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls\n",
+      "   0  0.0000000e+00 1.30e+06 1.00e+00  -1.0 0.00e+00    -  0.00e+00 0.00e+00   0\n",
+      "   1  0.0000000e+00 1.67e+07 5.52e+03  -1.0 1.17e+08    -  2.85e-01 9.90e-01f  1\n",
+      "   2  0.0000000e+00 2.61e+05 6.25e+03  -1.0 1.17e+06    -  8.25e-01 9.90e-01h  1\n",
+      "   3  0.0000000e+00 2.59e+03 3.50e+01  -1.0 1.17e+04    -  9.90e-01 9.90e-01h  1\n",
+      "   4  0.0000000e+00 1.97e+01 3.22e+03  -1.0 1.15e+02    -  9.90e-01 9.92e-01h  1\n",
+      "   5  0.0000000e+00 3.19e-07 4.81e+03  -1.0 8.77e-01    -  9.91e-01 1.00e+00h  1\n",
+      "Cannot recompute multipliers for feasibility problem.  Error in eq_mult_calculator\n",
+      "\n",
+      "Number of Iterations....: 5\n",
+      "\n",
+      "                                   (scaled)                 (unscaled)\n",
+      "Objective...............:   0.0000000000000000e+00    0.0000000000000000e+00\n",
+      "Dual infeasibility......:   1.6686898115291998e+06    1.6686898115291998e+06\n",
+      "Constraint violation....:   3.1874515116214752e-07    3.1874515116214752e-07\n",
+      "Complementarity.........:   0.0000000000000000e+00    0.0000000000000000e+00\n",
+      "Overall NLP error.......:   3.1874515116214752e-07    1.6686898115291998e+06\n",
+      "\n",
+      "\n",
+      "Number of objective function evaluations             = 6\n",
+      "Number of objective gradient evaluations             = 6\n",
+      "Number of equality constraint evaluations            = 6\n",
+      "Number of inequality constraint evaluations          = 0\n",
+      "Number of equality constraint Jacobian evaluations   = 6\n",
+      "Number of inequality constraint Jacobian evaluations = 0\n",
+      "Number of Lagrangian Hessian evaluations             = 5\n",
+      "Total CPU secs in IPOPT (w/o function evaluations)   =      0.012\n",
+      "Total CPU secs in NLP function evaluations           =      0.002\n",
+      "\n",
+      "EXIT: Optimal Solution Found.\n"
+     ]
+    }
+   ],
    "source": [
     "# Solve the model\n",
     "results = solver.solve(m, tee=True)"
@@ -580,7 +714,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {
     "tags": [
      "testing"
@@ -606,16 +740,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "operating cost = $41.550 million per year\n"
+     ]
+    }
+   ],
    "source": [
     "print(f\"operating cost = ${value(m.fs.operating_cost)/1e6:0.3f} million per year\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {
     "tags": [
      "testing"
@@ -625,7 +767,7 @@
    "source": [
     "import pytest\n",
     "\n",
-    "assert value(m.fs.operating_cost) / 1e6 == pytest.approx(43.175798, abs=1e-3)"
+    "assert value(m.fs.operating_cost) / 1e6 == pytest.approx(41.550, abs=1e-3)"
    ]
   },
   {
@@ -637,9 +779,47 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "====================================================================================\n",
+      "Unit : fs.R101                                                             Time: 0.0\n",
+      "------------------------------------------------------------------------------------\n",
+      "    Unit Performance\n",
+      "\n",
+      "    Variables: \n",
+      "\n",
+      "    Key  : Value  : Units      : Fixed : Bounds\n",
+      "    Area : 1.1490 : meter ** 2 : False : (None, None)\n",
+      "\n",
+      "------------------------------------------------------------------------------------\n",
+      "    Stream Table\n",
+      "                                                  Units         Inlet     Outlet  \n",
+      "    Molar Flowrate ('Liq', 'ethylene_oxide')   mole / second     58.000     29.000\n",
+      "    Molar Flowrate ('Liq', 'water')            mole / second     239.60     210.60\n",
+      "    Molar Flowrate ('Liq', 'sulfuric_acid')    mole / second    0.33401    0.33401\n",
+      "    Molar Flowrate ('Liq', 'ethylene_glycol')  mole / second 2.0000e-05     29.000\n",
+      "    Temperature                                       kelvin     328.15     328.15\n",
+      "    Pressure                                          pascal 1.0000e+05 1.0000e+05\n",
+      "====================================================================================\n",
+      "\n",
+      "Conversion achieved = 50.0%\n",
+      "\n",
+      "Total heat duty required = -69.376 MJ\n",
+      "\n",
+      "Tube area required = 1.149 m^2\n",
+      "\n",
+      "Tube length required = 1.000 m\n",
+      "\n",
+      "Tube volume required = 1.149 m^3\n"
+     ]
+    }
+   ],
    "source": [
     "m.fs.R101.report()\n",
     "\n",
@@ -648,7 +828,9 @@
     "print()\n",
     "print(\n",
     "    f\"Total heat duty required = \"\n",
-    "    f\"{value(sum(m.fs.R101.heat_duty[0, x] for x in m.fs.R101.control_volume.length_domain))/1e6:0.3f}\"\n",
+    "    f\"\"\"{(value(sum(m.fs.R101.heat_duty[0, k] for k in  m.fs.R101.control_volume.length_domain if 0.0 <= k < 1.0))\n",
+    "    + (value(m.fs.R101.heat_duty[0, m.fs.R101.control_volume.length_domain.at(1)])\n",
+    "    + value(m.fs.R101.heat_duty[0, m.fs.R101.control_volume.length_domain.at(-1)]))/2)/1e6:0.3f}\"\"\"\n",
     "    f\" MJ\"\n",
     ")\n",
     "print()\n",
@@ -661,7 +843,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {
     "tags": [
      "testing"
@@ -671,9 +853,10 @@
    "source": [
     "assert value(m.fs.R101.conversion) == pytest.approx(0.5000, abs=1e-3)\n",
     "assert value(m.fs.R101.area) == pytest.approx(1.1490, abs=1e-3)\n",
-    "assert value(\n",
-    "    sum(m.fs.R101.heat_duty[0, x] for x in m.fs.R101.control_volume.length_domain)\n",
-    ") / 1e6 == pytest.approx(-70.708, abs=1e-3)\n",
+    "assert (value(sum(m.fs.R101.heat_duty[0, k] for k in  m.fs.R101.control_volume.length_domain if 0.0 <= k < 1.0))\n",
+    "    + (value(m.fs.R101.heat_duty[0, m.fs.R101.control_volume.length_domain.at(1)])\n",
+    "    + value(m.fs.R101.heat_duty[0, m.fs.R101.control_volume.length_domain.at(-1)]))/2)/1e6 \\\n",
+    "    == pytest.approx(-69.376, abs=1e-3)\n",
     "assert value(m.fs.R101.outlet.temperature[0]) / 1e2 == pytest.approx(3.2815, abs=1e-3)"
    ]
   },
@@ -695,7 +878,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -711,7 +894,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -743,7 +926,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {
     "tags": [
      "testing"
@@ -766,18 +949,116 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ipopt 3.13.2: nlp_scaling_method=gradient-based\n",
+      "tol=1e-06\n",
+      "max_iter=200\n",
+      "\n",
+      "\n",
+      "******************************************************************************\n",
+      "This program contains Ipopt, a library for large-scale nonlinear optimization.\n",
+      " Ipopt is released as open source code under the Eclipse Public License (EPL).\n",
+      "         For more information visit http://projects.coin-or.org/Ipopt\n",
+      "\n",
+      "This version of Ipopt was compiled from source code available at\n",
+      "    https://github.com/IDAES/Ipopt as part of the Institute for the Design of\n",
+      "    Advanced Energy Systems Process Systems Engineering Framework (IDAES PSE\n",
+      "    Framework) Copyright (c) 2018-2019. See https://github.com/IDAES/idaes-pse.\n",
+      "\n",
+      "This version of Ipopt was compiled using HSL, a collection of Fortran codes\n",
+      "    for large-scale scientific computation.  All technical papers, sales and\n",
+      "    publicity material resulting from use of the HSL codes within IPOPT must\n",
+      "    contain the following acknowledgement:\n",
+      "        HSL, a collection of Fortran codes for large-scale scientific\n",
+      "        computation. See http://www.hsl.rl.ac.uk.\n",
+      "******************************************************************************\n",
+      "\n",
+      "This is Ipopt version 3.13.2, running with linear solver ma27.\n",
+      "\n",
+      "Number of nonzeros in equality constraint Jacobian...:     2067\n",
+      "Number of nonzeros in inequality constraint Jacobian.:        1\n",
+      "Number of nonzeros in Lagrangian Hessian.............:     1674\n",
+      "\n",
+      "Total number of variables............................:      631\n",
+      "                     variables with only lower bounds:        0\n",
+      "                variables with lower and upper bounds:      280\n",
+      "                     variables with only upper bounds:       21\n",
+      "Total number of equality constraints.................:      608\n",
+      "Total number of inequality constraints...............:        1\n",
+      "        inequality constraints with only lower bounds:        1\n",
+      "   inequality constraints with lower and upper bounds:        0\n",
+      "        inequality constraints with only upper bounds:        0\n",
+      "\n",
+      "iter    objective    inf_pr   inf_du lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls\n",
+      "   0  4.1550046e+07 3.66e+06 6.34e+00  -1.0 0.00e+00    -  0.00e+00 0.00e+00   0\n",
+      "   1  4.1378724e+07 3.63e+06 1.06e+01  -1.0 2.73e+06    -  7.82e-02 6.75e-03f  1\n",
+      "   2  3.9196464e+07 3.33e+06 1.75e+01  -1.0 2.81e+06    -  1.39e-01 8.38e-02f  1\n",
+      "   3  1.3440700e+07 2.48e+06 2.13e+02  -1.0 2.80e+06    -  4.57e-01 9.90e-01f  1\n",
+      "   4  7.7388205e+06 2.02e+06 1.40e+02  -1.0 7.05e+06    -  6.59e-01 5.41e-01f  1\n",
+      "   5  7.7151867e+06 2.01e+06 1.73e+03  -1.0 1.14e+07    -  6.75e-01 3.34e-03f  1\n",
+      "   6  7.7140719e+06 2.01e+06 7.57e+04  -1.0 4.51e+07    -  9.59e-02 2.58e-04f  1\n",
+      "   7  6.5187886e+06 1.61e+06 2.16e+04  -1.0 6.07e+07    -  1.16e-01 1.98e-01f  1\n",
+      "   8  5.0842099e+06 1.27e+06 1.61e+04  -1.0 5.82e+07    -  2.54e-01 2.12e-01f  1\n",
+      "   9  3.2467016e+06 8.24e+05 3.69e+04  -1.0 4.53e+07    -  2.51e-02 3.51e-01f  1\n",
+      "iter    objective    inf_pr   inf_du lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls\n",
+      "  10  2.8088038e+06 7.16e+05 4.01e+04  -1.0 2.91e+07    -  3.83e-02 1.31e-01f  1\n",
+      "  11  2.8024820e+06 7.15e+05 1.63e+04  -1.0 2.52e+07    -  6.69e-01 2.19e-03f  1\n",
+      "  12  2.7199113e+06 6.94e+05 3.98e+04  -1.0 2.49e+07    -  8.85e-01 2.93e-02f  1\n",
+      "  13  2.7148186e+06 6.92e+05 3.67e+04  -1.0 2.37e+07    -  9.90e-01 1.93e-03f  1\n",
+      "  14  2.4824443e+06 6.30e+05 2.77e+04  -1.0 2.35e+07    -  1.00e+00 8.93e-02f  1\n",
+      "  15  2.2916619e+06 5.77e+05 2.59e+04  -1.0 2.08e+07    -  1.00e+00 8.45e-02f  1\n",
+      "  16  2.1045870e+06 5.21e+05 3.82e+04  -1.0 1.83e+07    -  1.00e+00 9.81e-02f  1\n",
+      "  17  1.9568303e+06 4.69e+05 6.93e+04  -1.0 1.53e+07    -  1.00e+00 9.92e-02f  1\n",
+      "  18  1.8483481e+06 4.20e+05 1.11e+05  -1.0 1.23e+07    -  1.00e+00 1.05e-01f  1\n",
+      "  19  1.7640283e+06 3.66e+05 1.73e+05  -1.0 9.68e+06    -  1.00e+00 1.28e-01f  1\n",
+      "iter    objective    inf_pr   inf_du lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls\n",
+      "  20  1.6815328e+06 3.07e+05 2.53e+05  -1.0 8.13e+06    -  1.00e+00 1.61e-01f  1\n",
+      "  21  1.3731943e+06 8.50e+04 1.73e+06  -1.0 6.81e+06    -  1.00e+00 7.23e-01f  1\n",
+      "  22  1.2731417e+06 9.87e+03 4.44e+05  -1.0 1.86e+06    -  1.00e+00 8.84e-01f  1\n",
+      "  23  1.2604250e+06 2.00e+01 4.99e+03  -1.0 2.14e+05    -  1.00e+00 1.00e+00f  1\n",
+      "  24  1.2604308e+06 1.77e-06 1.65e+03  -1.0 2.88e+01    -  9.99e-01 1.00e+00h  1\n",
+      "  25  1.2604289e+06 5.12e-07 5.48e-06  -1.7 8.33e+00    -  1.00e+00 1.00e+00f  1\n",
+      "  26  1.2604284e+06 3.05e-07 4.75e-07  -5.7 2.08e+00    -  1.00e+00 1.00e+00f  1\n",
+      "\n",
+      "Number of Iterations....: 26\n",
+      "\n",
+      "                                   (scaled)                 (unscaled)\n",
+      "Objective...............:   1.2604284374288018e+06    1.2604284374288018e+06\n",
+      "Dual infeasibility......:   4.7538605248836907e-07    4.7538605248836907e-07\n",
+      "Constraint violation....:   3.0535738915205002e-07    3.0535738915205002e-07\n",
+      "Complementarity.........:   1.9274477540397112e-06    1.9274477540397112e-06\n",
+      "Overall NLP error.......:   3.1172766041989730e-07    1.9274477540397112e-06\n",
+      "\n",
+      "\n",
+      "Number of objective function evaluations             = 27\n",
+      "Number of objective gradient evaluations             = 27\n",
+      "Number of equality constraint evaluations            = 27\n",
+      "Number of inequality constraint evaluations          = 27\n",
+      "Number of equality constraint Jacobian evaluations   = 27\n",
+      "Number of inequality constraint Jacobian evaluations = 27\n",
+      "Number of Lagrangian Hessian evaluations             = 26\n",
+      "Total CPU secs in IPOPT (w/o function evaluations)   =      0.069\n",
+      "Total CPU secs in NLP function evaluations           =      0.005\n",
+      "\n",
+      "EXIT: Optimal Solution Found.\n"
+     ]
+    }
+   ],
    "source": [
     "results = solver.solve(m, tee=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {
     "tags": [
      "testing"
@@ -793,9 +1074,63 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "operating cost = $1.260 million per year\n",
+      "\n",
+      "Heater results\n",
+      "\n",
+      "====================================================================================\n",
+      "Unit : fs.H101                                                             Time: 0.0\n",
+      "------------------------------------------------------------------------------------\n",
+      "    Unit Performance\n",
+      "\n",
+      "    Variables: \n",
+      "\n",
+      "    Key       : Value  : Units : Fixed : Bounds\n",
+      "    Heat Duty : 699.26 :  watt : False : (None, None)\n",
+      "\n",
+      "------------------------------------------------------------------------------------\n",
+      "    Stream Table\n",
+      "                                                  Units         Inlet     Outlet  \n",
+      "    Molar Flowrate ('Liq', 'ethylene_oxide')   mole / second     58.000     58.000\n",
+      "    Molar Flowrate ('Liq', 'water')            mole / second     239.60     239.60\n",
+      "    Molar Flowrate ('Liq', 'sulfuric_acid')    mole / second    0.33401    0.33401\n",
+      "    Molar Flowrate ('Liq', 'ethylene_glycol')  mole / second 2.0000e-05 2.0000e-05\n",
+      "    Temperature                                       kelvin     298.15     328.15\n",
+      "    Pressure                                          pascal 1.0000e+05 1.0000e+05\n",
+      "====================================================================================\n",
+      "\n",
+      "PFR reactor results\n",
+      "\n",
+      "====================================================================================\n",
+      "Unit : fs.R101                                                             Time: 0.0\n",
+      "------------------------------------------------------------------------------------\n",
+      "    Unit Performance\n",
+      "\n",
+      "    Variables: \n",
+      "\n",
+      "    Key  : Value  : Units      : Fixed : Bounds\n",
+      "    Area : 2.0782 : meter ** 2 : False : (None, None)\n",
+      "\n",
+      "------------------------------------------------------------------------------------\n",
+      "    Stream Table\n",
+      "                                                  Units         Inlet     Outlet  \n",
+      "    Molar Flowrate ('Liq', 'ethylene_oxide')   mole / second     58.000     5.8000\n",
+      "    Molar Flowrate ('Liq', 'water')            mole / second     239.60     187.40\n",
+      "    Molar Flowrate ('Liq', 'sulfuric_acid')    mole / second    0.33401    0.33401\n",
+      "    Molar Flowrate ('Liq', 'ethylene_glycol')  mole / second 2.0000e-05     52.200\n",
+      "    Temperature                                       kelvin     328.15     273.15\n",
+      "    Pressure                                          pascal 1.0000e+05 1.0000e+05\n",
+      "====================================================================================\n"
+     ]
+    }
+   ],
    "source": [
     "print(f\"operating cost = ${value(m.fs.operating_cost)/1e6:0.3f} million per year\")\n",
     "\n",
@@ -812,7 +1147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {
     "tags": [
      "testing"
@@ -820,8 +1155,8 @@
    },
    "outputs": [],
    "source": [
-    "assert value(m.fs.operating_cost) / 1e6 == pytest.approx(15.538911, abs=1e-3)\n",
-    "assert value(m.fs.R101.area) == pytest.approx(2.7874, abs=1e-3)"
+    "assert value(m.fs.operating_cost) / 1e6 == pytest.approx(1.260, abs=1e-3)\n",
+    "assert value(m.fs.R101.area) == pytest.approx(2.0782, abs=1e-3)"
    ]
   },
   {
@@ -833,9 +1168,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Optimal Values\n",
+      "\n",
+      "H101 outlet temperature = 328.150 K\n",
+      "\n",
+      "Total heat duty required =  -13.758 MJ\n",
+      "\n",
+      "Tube area required = 2.078 m^2\n",
+      "\n",
+      "Tube length required = 5.000 m\n",
+      "\n",
+      "Assuming a 20% design factor for reactor volume,total CSTR volume required = 12.469 m^3 = 3294.093 gal\n",
+      "\n",
+      "Ethylene glycol produced = 225.415 MM lb/year\n",
+      "\n",
+      "Conversion achieved = 90.0%\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"Optimal Values\")\n",
     "print()\n",
@@ -843,13 +1200,11 @@
     "print(f\"H101 outlet temperature = {value(m.fs.H101.outlet.temperature[0]):0.3f} K\")\n",
     "\n",
     "print()\n",
-    "print(\n",
-    "    \"Total heat duty required = \",\n",
-    "    value(\n",
-    "        sum(m.fs.R101.heat_duty[0, x] for x in m.fs.R101.control_volume.length_domain)\n",
-    "    )\n",
-    "    / 1e6,\n",
-    "    \"MJ\",\n",
+    "print(\"Total heat duty required = \",\n",
+    "    f\"\"\"{(value(sum(m.fs.R101.heat_duty[0, k] for k in  m.fs.R101.control_volume.length_domain if 0.0 <= k < 1.0))\n",
+    "    + (value(m.fs.R101.heat_duty[0, m.fs.R101.control_volume.length_domain.at(1)])\n",
+    "    + value(m.fs.R101.heat_duty[0, m.fs.R101.control_volume.length_domain.at(-1)]))/2)/1e6:0.3f}\"\"\"\n",
+    "    f\" MJ\"\n",
     ")\n",
     "print()\n",
     "print(f\"Tube area required = {value(m.fs.R101.area):0.3f} m^2\")\n",
@@ -873,7 +1228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {
     "tags": [
      "testing"
@@ -882,15 +1237,23 @@
    "outputs": [],
    "source": [
     "assert value(m.fs.H101.outlet.temperature[0]) / 100 == pytest.approx(3.2815, abs=1e-3)\n",
-    "assert value(\n",
-    "    sum(m.fs.R101.heat_duty[0, x] for x in m.fs.R101.control_volume.length_domain)\n",
-    ") / 1e6 == pytest.approx(-25.443, abs=1e-3)\n",
-    "assert value(m.fs.R101.area) == pytest.approx(2.7874, abs=1e-3)\n",
+    "assert (value(sum(m.fs.R101.heat_duty[0, k] for k in  m.fs.R101.control_volume.length_domain if 0.0 <= k < 1.0))\n",
+    "    + (value(m.fs.R101.heat_duty[0, m.fs.R101.control_volume.length_domain.at(1)])\n",
+    "    + value(m.fs.R101.heat_duty[0, m.fs.R101.control_volume.length_domain.at(-1)]))/2)/1e6 \\\n",
+    "    == pytest.approx(-13.758, abs=1e-3)\n",
+    "assert value(m.fs.R101.area) == pytest.approx(2.078, abs=1e-3)\n",
     "assert value(m.fs.R101.control_volume.length) == pytest.approx(5.000, abs=1e-3)\n",
-    "assert value(m.fs.R101.volume * 1.2) == pytest.approx(16.725, abs=1e-3)\n",
+    "assert value(m.fs.R101.volume * 1.2) == pytest.approx(12.469, abs=1e-3)\n",
     "assert value(m.fs.eg_prod) == pytest.approx(225.415, abs=1e-3)\n",
     "assert value(m.fs.R101.conversion) * 100 == pytest.approx(90.000, abs=1e-3)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -917,7 +1280,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.8.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Title

Fixes #46 
- fixes units for PFR example

{Description}
- fixes units for PFR example
- change calculation for reactor heat duty to trapezoid rule
----
Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

    I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
    I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
