### PR TITLE
Fixing instructions in developers README on how to run pytest

### DIFF
--- a/README-developer.md
+++ b/README-developer.md
@@ -102,7 +102,7 @@ you need to add `-c` and the path to the top-level *pyproject.toml*, which has t
 then use the name of the test notebook:
 
 ```shell
-pytest -v idaes_examples/notebooks/docs/unit_models/operations/compressor_test.ipynb
+pytest -c idaes_examples/notebooks/docs/unit_models/operations/compressor_test.ipynb
 ```
 
 If you want to test several related notebooks, or perhaps just not type the whole notebook filename,


### PR DESCRIPTION
# Fixing typo

Fixes the flag for running a single notebook which should have been -c instead of -v in the developer readme. 

----
Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

    I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
    I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.


<!-- readthedocs-preview idaes-examples start -->
----
📚 Documentation preview 📚: https://idaes-examples--90.org.readthedocs.build/en/90/

<!-- readthedocs-preview idaes-examples end -->