### PR TITLE
Add explicit path to ReadtheDocs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,3 +15,5 @@ python:
 sphinx:
   builder: html
   fail_on_warning: false
+  configuration: idaes_examples/notebooks/conf.py
+


### PR DESCRIPTION
# Fixes #136 

Adding an explicit path to the repo's `conf.py` for RTD.

----
Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

    I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
    I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
