### PR TITLE
Update depreciated github artifact actions v3 to current v4

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -114,5 +114,5 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: pytest_worker_logs--${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+          name: pytest_worker_logs--${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ runner.os }}-py${{ matrix.python-version }}
           path: "tests_*.log"


### PR DESCRIPTION
# Title

Fixes [#{148}](https://github.com/IDAES/examples/issues/148)

Github deprecaited version 3 for artifact actions. 
1. Changed upload-artifact from version 3 to version 4
2. Created a unique name identifier since a key change in version 4 is that run names cannot be the same. See [breaking changes](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes) in version 4 documentation for more details.

----
Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

    I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
    I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.


<!-- readthedocs-preview idaes-examples start -->
----
📚 Documentation preview 📚: https://idaes-examples--149.org.readthedocs.build/en/149/

<!-- readthedocs-preview idaes-examples end -->