### PR TITLE
Drop Python 3.9 and add Python 3.13

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -82,10 +82,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
         os:
           - linux
           - win64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "IDAES Process Systems Engineering Examples"
 readme = "README.md"
 version = "2.10.dev0"
 license = {text="BSD"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     {name="The IDAES Project"},
     {name="Dan Gunter", email="dkgunter@lbl.gov"}
@@ -28,10 +28,10 @@ classifiers = [
         "Operating System :: Unix",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Scientific/Engineering :: Mathematics",
         "Topic :: Scientific/Engineering :: Chemistry",


### PR DESCRIPTION
Following similar recent PRs in idaes-pse, this PR drops Python 3.9 and adds Python 3.13. 

----
Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

    I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
    I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.


<!-- readthedocs-preview idaes-examples start -->
----
📚 Documentation preview 📚: https://idaes-examples--164.org.readthedocs.build/en/164/

<!-- readthedocs-preview idaes-examples end -->