### PR TITLE
Updating Ubuntu runner for RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.10"
   jobs:


### PR DESCRIPTION
# Updating Ubuntu runner for RTD

RTD is deprecating the 20.04 runner, so this updates ours to 24.04

----
Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

    I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
    I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.


<!-- readthedocs-preview idaes-examples start -->
----
📚 Documentation preview 📚: https://idaes-examples--166.org.readthedocs.build/en/166/

<!-- readthedocs-preview idaes-examples end -->