### PR TITLE
Upgrade CI for Node 24 Migration

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -101,6 +101,9 @@ jobs:
         with:
           activate-environment: ${{ env.IDAES_CONDA_ENV_NAME_DEV }}
           python-version: ${{ matrix.python-version }}
+          miniforge-version: latest
+          channels: conda-forge
+          conda-remove-defaults: 'true'
       - name: Install the code
         uses: ./.github/actions/install
         with:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -53,8 +53,8 @@ jobs:
     # OS and/or Python version don't make a difference, so we choose ubuntu and 3.10 for performance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
       - name: Install Black
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run Spell Checker
         uses: crate-ci/typos@master
 
@@ -95,9 +95,9 @@ jobs:
           - os: win64
             runner-image: windows-2022
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Conda environment
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v4
         with:
           activate-environment: ${{ env.IDAES_CONDA_ENV_NAME_DEV }}
           python-version: ${{ matrix.python-version }}
@@ -115,7 +115,7 @@ jobs:
           pytest -v idaes_examples --ignore=idaes_examples/notebooks/docs/surrogates/sco2/alamo/ 
       - name: Upload pytest-xdist worker logs
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pytest_worker_logs--${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ runner.os }}-py${{ matrix.python-version }}
           path: "tests_*.log"


### PR DESCRIPTION
# Title
Node 24 mirgration has happened and CI is still using actions on node 20.

{Description}

----
Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

    I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
    I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.


<!-- readthedocs-preview idaes-examples start -->
----
📚 Documentation preview 📚: https://idaes-examples--171.org.readthedocs.build/en/171/

<!-- readthedocs-preview idaes-examples end -->